### PR TITLE
Task #124742 feat : New feature - Auto save

### DIFF
--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -10,9 +10,12 @@ function steppedFormSave(form_id, status)
 
 		if(confirm(Joomla.JText._('COM_TJUCM_ITEMFORM_ALERT')) == true)
 		{
+			/* code to remove the class added by are-you-sure alert box */
+			jQuery('#item-form').removeClass('dirty');
+
 			if (!document.formvalidator.isValid('#item-form'))
 			{
-					return false;
+				return false;
 			}
 		}
 		else

--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -48,8 +48,6 @@ function steppedFormSave(form_id, status)
 					{
 						jQuery("#recordId").val(returnedData.data);
 						promise = true;
-						jQuery("#draft_msg").show();
-						setTimeout(function() { jQuery("#draft_msg").hide(); }, 5000);
 					}
 				}
 				else

--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -7,6 +7,7 @@ function steppedFormSave(form_id, status)
 	jQuery('#form_status').val(status);
 
 	if ('save' == status) {
+
 		if(confirm(Joomla.JText._('COM_TJUCM_ITEMFORM_ALERT')) == true)
 		{
 			if (!document.formvalidator.isValid('#item-form'))

--- a/administrator/models/type.php
+++ b/administrator/models/type.php
@@ -3,7 +3,7 @@
  * @version    SVN: <svn_id>
  * @package    Com_Tjucm
  * @author     Techjoomla <extensions@techjoomla.com>
- * @copyright  Copyright (c) 2009-2017 TechJoomla. All rights reserved.
+ * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  * @license    GNU General Public License version 2 or later.
  */
 
@@ -326,7 +326,6 @@ class TjucmModelType extends JModelAdmin
 
 		$params = array();
 		$params['allowed_count'] = $data['allowed_count'];
-		$params['allow_draft_save'] = $data['allow_draft_save'];
 		$params['is_subform'] = $data['is_subform'];
 
 		$data['params'] = json_encode($params);

--- a/administrator/views/type/tmpl/edit.php
+++ b/administrator/views/type/tmpl/edit.php
@@ -53,15 +53,10 @@ JHtml::script( JUri::root().'administrator/components/com_tjucm/assets/js/tjucm_
 							<input type="hidden" name="jform[id]" value="<?php echo $this->item->id; ?>" />
 							<input type="hidden" name="jform[ordering]" value="<?php echo $this->item->ordering; ?>" />
 							<?php echo $this->form->renderField('title'); ?>
-							<?php
-							/*if ($this->item->field_group || $this->item->field_category) {
-								$this->form->setFieldAttribute('alias', 'readonly', 'true', $group = null);
-							}*/ ?>
 							<?php echo $this->form->renderField('alias'); ?>
 							<?php echo $this->form->renderField('unique_identifier'); ?>
 							<?php echo $this->form->renderField('state'); ?>
 							<?php echo $this->form->renderField('allowed_count'); ?>
-							<?php echo $this->form->renderField('allow_draft_save'); ?>
 							<?php echo $this->form->renderField('is_subform'); ?>
 							<?php echo $this->form->renderField('type_description'); ?>
 

--- a/site/controllers/itemform.php
+++ b/site/controllers/itemform.php
@@ -203,9 +203,10 @@ class TjucmControllerItemForm extends JControllerForm
 
 		// Get the user data.
 		$data = $app->input->get('jform', array(), 'array');
+
 		$all_jform_data = $data;
 
-		// get file information
+		// Get file information
 		$files = $app->input->files->get('jform');
 
 		// Jform tweak - Get all posted data.

--- a/site/models/itemform.php
+++ b/site/models/itemform.php
@@ -456,14 +456,7 @@ class TjucmModelItemForm extends JModelForm
 
 		$table = $this->getTable();
 
-		if ($status_title == 'draft')
-		{
-			$data['state'] = 0;
-		}
-		else
-		{
-			$data['state'] = 1;
-		}
+		$data['state'] = ($status_title == 'draft' ? 0 : 1);
 
 		if ($table->save($data) === true)
 		{

--- a/site/models/itemform.php
+++ b/site/models/itemform.php
@@ -215,6 +215,7 @@ class TjucmModelItemForm extends JModelForm
 		{
 			return JError::raiseError(404, JText::_('COM_TJUCM_ITEM_DOESNT_EXIST'));
 		}
+
 		return $this->item;
 	}
 
@@ -455,9 +456,13 @@ class TjucmModelItemForm extends JModelForm
 
 		$table = $this->getTable();
 
-		if ($id == 0)
+		if ($status_title == 'draft')
 		{
 			$data['state'] = 0;
+		}
+		else
+		{
+			$data['state'] = 1;
 		}
 
 		if ($table->save($data) === true)
@@ -472,7 +477,7 @@ class TjucmModelItemForm extends JModelForm
 				$data_extra['fieldsvalue'] = $extra_jform_data;
 
 				// Save extra fields data.
-				if(!$this->saveExtraFields($data_extra))
+				if (!$this->saveExtraFields($data_extra))
 				{
 					return false;
 				}

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -24,20 +24,8 @@ $doc->addScript(JUri::root() . 'administrator/components/com_tjucm/assets/js/tju
 $doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/tjfields.js');
 $doc->addScript(JUri::root() . 'media/com_tjucm/js/form.js');
 
-/*
- * Script to show alert box if form changes are made and user is closing the tab or refreshing the tab
- * without saving the content
- */
-$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/jquery.are-you-sure.js');
-
-/*
- * Script to show alert box if form changes are made and user is closing the tab or refreshing the tab
- * without saving the content on iphone|ipad|ipod|opera
- */
-$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/ays-beforeunload-shim.js');
-$doc->addStyleSheet(JUri::root() . 'media/com_tjucm/css/tjucm.css');
-
 $jinput                    = JFactory::getApplication();
+$editRecordId              = $jinput->input->get("id", '', 'INT');
 $baseUrl                   = $jinput->input->server->get('REQUEST_URI', '', 'STRING');
 $calledFrom                = (strpos($baseUrl, 'administrator')) ? 'backend' : 'frontend';
 $layout                    = ($calledFrom == 'frontend') ? 'default' : 'edit';
@@ -46,8 +34,37 @@ $fieldsets_counter_deafult = 0;
 $app                       = JFactory::getApplication();
 $menu                      = $app->getMenu();
 $setnavigation             = false;
+
+if ($editRecordId)
+{
+	/*
+	 * Script to show alert box if form changes are made and user is closing the tab or refreshing the tab
+	 * without saving the content
+	 */
+	$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/jquery.are-you-sure.js');
+
+	/*
+	 * Script to show alert box if form changes are made and user is closing the tab or refreshing the tab
+	 * without saving the content on iphone|ipad|ipod|opera
+	 */
+	$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/ays-beforeunload-shim.js');
+	$doc->addStyleSheet(JUri::root() . 'media/com_tjucm/css/tjucm.css');
+}
 ?>
 <script type="text/javascript">
+
+	/* Code to show alert box if form changes are made and user is closing the tab or refreshing the tab
+	 * without saving the content
+	 */
+	var editRecordId = '<?php echo $editRecordId; ?>';
+
+	if (editRecordId)
+	{
+		jQuery(function() {
+			jQuery('#item-form').areYouSure();
+		});
+	}
+
 
 	jQuery(window).load(function ()
 	{

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -3,7 +3,7 @@
  * @version    SVN: <svn_id>
  * @package    Com_Tjucm
  * @author     Techjoomla <extensions@techjoomla.com>
- * @copyright  Copyright (c) 2009-2017 TechJoomla. All rights reserved.
+ * @copyright  Copyright (c) 2009-2018 TechJoomla. All rights reserved.
  * @license    GNU General Public License version 2 or later.
  */
 
@@ -23,6 +23,12 @@ $doc->addScript(JUri::root() . 'administrator/components/com_tjucm/assets/js/jqu
 $doc->addScript(JUri::root() . 'administrator/components/com_tjucm/assets/js/tjucm_ajaxForm_save.js');
 $doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/tjfields.js');
 $doc->addScript(JUri::root() . 'media/com_tjucm/js/form.js');
+
+// Script to show alert box if form changes are made and user is closing the tab or refreshing the tab without saving the content
+$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/jquery.are-you-sure.js');
+
+// Script to show alert box if form changes are made and user is closing the tab or refreshing the tab without saving the content on iphone|ipad|ipod|opera
+$doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/ays-beforeunload-shim.js');
 $doc->addStyleSheet(JUri::root() . 'media/com_tjucm/css/tjucm.css');
 
 $jinput                    = JFactory::getApplication();
@@ -62,7 +68,8 @@ $setnavigation             = false;
 	}
 </script>
 
-<form action="<?php echo JRoute::_('index.php'); ?>" method="post" enctype="multipart/form-data" name="adminForm" id="item-form" class="form-validate">
+<form action="<?php echo JRoute::_('index.php'); ?>" method="post"
+enctype="multipart/form-data" name="adminForm" id="item-form" class="form-validate">
 	<?php
 	if ($is_saved)
 	{
@@ -71,7 +78,7 @@ $setnavigation             = false;
 			<a class="close" data-dismiss="alert">×</a>
 			<div class="msg">
 				<?php
-					echo JText::sprintf( 'COM_TJUCM_MSG_ON_SAVED_FORM');
+					echo JText::sprintf('COM_TJUCM_MSG_ON_SAVED_FORM');
 				?>
 			</div>
 		</div>
@@ -134,8 +141,14 @@ $setnavigation             = false;
 				if (!empty($this->allow_draft_save))
 				{
 				?>
-					<button type="button" class="btn btn-primary" id="previous_button" onclick="itemformactions('tjucm_myTab','prev')"><?php echo JText::_('COM_TJUCM_PREVIOUS_BUTTON'); ?><i class="icon-arrow-right-2"></i></button>
-					<button type="button" class="btn btn-primary" id="next_button" onclick="itemformactions('tjucm_myTab','next')"><?php echo JText::_('COM_TJUCM_NEXT_BUTTON'); ?><i class="icon-arrow-right-2"></i></button>
+					<button type="button" class="btn btn-primary" id="previous_button"
+					onclick="itemformactions('tjucm_myTab','prev')">
+					<?php echo JText::_('COM_TJUCM_PREVIOUS_BUTTON'); ?>
+					<i class="icon-arrow-right-2"></i></button>
+					<button type="button" class="btn btn-primary" id="next_button"
+					onclick="itemformactions('tjucm_myTab','next')">
+					<?php echo JText::_('COM_TJUCM_NEXT_BUTTON'); ?>
+					<i class="icon-arrow-right-2"></i></button>
 				<?php
 				}
 			}
@@ -143,12 +156,14 @@ $setnavigation             = false;
 			if ($calledFrom == 'frontend')
 			{
 				?>
-				<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_ITEM"); ?>" id="finalSave" onclick="steppedFormSave(this.form.id, 'save');" />
+				<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_ITEM"); ?>"
+				id="finalSave" onclick="steppedFormSave(this.form.id, 'save');" />
 				<?php
 				if (!empty($this->allow_draft_save))
 				{
 					?>
-					<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="steppedFormSave(this.form.id, 'draft');" />
+					<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>"
+					onclick="steppedFormSave(this.form.id, 'draft');" />
 					<?php
 				}
 			}

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -142,10 +142,6 @@ enctype="multipart/form-data" name="adminForm" id="item-form" class="form-valida
 				</div>
 			</div>
 		</div>
-		<div id="draft_msg" class="alert alert-success" style="display: none;">
-			<a class="close" data-dismiss="alert">×</a>
-			<?php echo JText::_("COM_TJUCM_MSG_ON_DRAFT_FORM"); ?>
-		</div>
 		<div class="form-actions">
 			<?php
 			// Show next previous buttons only when there are mulitple tabs/groups present under that field type

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -24,10 +24,16 @@ $doc->addScript(JUri::root() . 'administrator/components/com_tjucm/assets/js/tju
 $doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/tjfields.js');
 $doc->addScript(JUri::root() . 'media/com_tjucm/js/form.js');
 
-// Script to show alert box if form changes are made and user is closing the tab or refreshing the tab without saving the content
+/*
+ * Script to show alert box if form changes are made and user is closing the tab or refreshing the tab
+ * without saving the content
+ */
 $doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/jquery.are-you-sure.js');
 
-// Script to show alert box if form changes are made and user is closing the tab or refreshing the tab without saving the content on iphone|ipad|ipod|opera
+/*
+ * Script to show alert box if form changes are made and user is closing the tab or refreshing the tab
+ * without saving the content on iphone|ipad|ipod|opera
+ */
 $doc->addScript(JUri::root() . 'administrator/components/com_tjfields/assets/js/ays-beforeunload-shim.js');
 $doc->addStyleSheet(JUri::root() . 'media/com_tjucm/css/tjucm.css');
 
@@ -159,13 +165,6 @@ enctype="multipart/form-data" name="adminForm" id="item-form" class="form-valida
 				<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_ITEM"); ?>"
 				id="finalSave" onclick="steppedFormSave(this.form.id, 'save');" />
 				<?php
-				if (!empty($this->allow_draft_save))
-				{
-					?>
-					<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>"
-					onclick="steppedFormSave(this.form.id, 'draft');" />
-					<?php
-				}
 			}
 			?>
 		</div>


### PR DESCRIPTION
- Auto Save feature works on ‘onblur’ input trigger for every field.
- It saves the form in draft mode & it will work for new record only. 
- As auto save saves the form in draft mode, we have removed "Allowed As Draft" param from admin panel & save draft button wont be anymore on site panel.

**Note :** After final submit you can edit the form. But autosave functionality will be disabled on edit form.

Regarding the UX concern while editing the form, we are alerting the user about unsaved changes before closing the page or refreshing the page.
