### PR TITLE
Bug #127465 fix: show popup only if there are unsaved data within form

### DIFF
--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -32,6 +32,7 @@ function steppedFormSave(form_id, status)
 				var returnedData = JSON.parse(data);
 				if(returnedData.data != null)
 				{
+					jQuery('#item-form').removeClass('dirty');
 					if ('save' == status) {
 						jQuery("#finalSave").attr("disabled", "disabled");
 						var url= window.location.href.split('#')[0],


### PR DESCRIPTION
Show alert popup only if there are unsaved data within form & user goes to close or refresh that tab.