### PR TITLE
Issue #131881 fix: UCM added multiple entries after submitting the form

### DIFF
--- a/site/controllers/itemform.php
+++ b/site/controllers/itemform.php
@@ -341,8 +341,6 @@ class TjucmControllerItemForm extends JControllerForm
 				return false;
 			}
 
-			$formExtra = array_filter($formExtra);
-
 			if (!empty($formExtra))
 			{
 				// Remove required attribute from fields if data is stored in draft mode


### PR DESCRIPTION
Fill one of the fields from UCM form then either goto next field (in case of autosave) or click directly on "Save as draft" button then again update the same form by adding/updating values in existing fields. It will add new UCM item entries for each update.

**NOTE :** This issue happens only when your site's error_repoprting is on(set as maximum).

We have removed array_filter() PHP function as there is no need of this function anymore. We have used this function in our old UCM versions. 