### PR TITLE
'Save Section Progress' button does not hide after updating publish state from item list #38

### DIFF
--- a/site/models/item.php
+++ b/site/models/item.php
@@ -278,6 +278,7 @@ class TjucmModelItem extends JModelAdmin
 	{
 		$table = $this->getTable();
 		$table->load($id);
+		$table->draft = $state == 1 ? 0 : 1;
 		$table->state = $state;
 
 		return $table->store();

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -190,7 +190,7 @@ $itemState                 = $this->item->state;
 
 			if ($calledFrom == 'frontend')
 			{
-				if (!empty($this->allow_draft_save))
+				if (!empty($this->allow_draft_save) && empty($itemState))
 				{
 					?>
 					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="steppedFormSave(this.form.id, 'draft');" />


### PR DESCRIPTION
'Save Section Progress' button does not hide after updating publish state(saving as final submit) from item list for the particular item.