### PR TITLE
UCM type privileges not working on items (list) page as per the permission set in UCM type #40

### DIFF
--- a/site/views/items/tmpl/default.php
+++ b/site/views/items/tmpl/default.php
@@ -103,9 +103,9 @@ if (!empty($this->client))
 			{
 				foreach ($this->items as $i => $item)
 				{
-					 $link = JRoute::_('index.php?option=com_tjucm&view=item&id=' . $item->id . "&client=" . $this->client, false);
+					$link = JRoute::_('index.php?option=com_tjucm&view=item&id=' . $item->id . "&client=" . $this->client, false);
 
-				    $editown = true;
+					$editown = true;
 					if (!$this->canEdit && $this->canEditOwn)
 					{
 						$editown = (JFactory::getUser()->id == $item->created_by ? true : false);

--- a/site/views/items/tmpl/default.php
+++ b/site/views/items/tmpl/default.php
@@ -105,7 +105,7 @@ if (!empty($this->client))
 				{
 					$link = JRoute::_('index.php?option=com_tjucm&view=item&id=' . $item->id . "&client=" . $this->client, false);
 
-					$editown = true;
+					$editown = false;
 					if (!$this->canEdit && $this->canEditOwn)
 					{
 						$editown = (JFactory::getUser()->id == $item->created_by ? true : false);

--- a/site/views/items/tmpl/default.php
+++ b/site/views/items/tmpl/default.php
@@ -105,10 +105,12 @@ if (!empty($this->client))
 				{
 					 $link = JRoute::_('index.php?option=com_tjucm&view=item&id=' . $item->id . "&client=" . $this->client, false);
 
+				    $editown = true;
 					if (!$this->canEdit && $this->canEditOwn)
 					{
-						$canEdit = JFactory::getUser()->id == $item->created_by;
+						$editown = (JFactory::getUser()->id == $item->created_by ? true : false);
 					}
+
 					?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<?php
@@ -155,18 +157,17 @@ if (!empty($this->client))
 								}
 							}
 
-							if ($canEdit || $this->canDelete)
+							if ($this->canEdit || $this->canDelete || $editown)
 							{
 								?>
 								<td class="center">
 								<?php
-								if ($canEdit)
+								if ($this->canEdit || $editown)
 								{
 									 ?>
 									<a target="_blank" href="<?php echo 'index.php?option=com_tjucm&task=itemform.edit&id=' . $item->id . $appendUrl; ?>" class="btn btn-mini" type="button"><i class="icon-apply" aria-hidden="true"></i></a>
 								<?php
 								}
-
 								if ($this->canDelete)
 								{
 									?>

--- a/site/views/items/tmpl/default.php
+++ b/site/views/items/tmpl/default.php
@@ -19,11 +19,6 @@ $user = JFactory::getUser();
 $userId = $user->get('id');
 $listOrder = $this->state->get('list.ordering');
 $listDirn = $this->state->get('list.direction');
-$canCreate = $user->authorise('core.type.createitem', 'com_tjucm.type.' . $this->ucmTypeId);
-$canEdit = $user->authorise('core.type.edititem', 'com_tjucm.type' . $this->ucmTypeId);
-$canChange = $user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $this->ucmTypeId);
-$canEditOwn = $user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId);
-
 $appendUrl = "";
 
 if (!empty($this->created_by))
@@ -35,8 +30,6 @@ if (!empty($this->client))
 {
 	$appendUrl .= "&client=" . $this->client;
 }
-
-$canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this->ucmTypeId);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_tjucm&view=items' . $appendUrl); ?>" method="post" name="adminForm" id="adminForm">
 	<table class="table table-striped" id="itemList">
@@ -74,7 +67,7 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 					}
 				}
 
-				if ($canEdit || $canDelete)
+				if ($this->canEdit || $this->canDelete)
 				{
 					?>
 					<th class="center">
@@ -111,9 +104,8 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 				foreach ($this->items as $i => $item)
 				{
 					 $link = JRoute::_('index.php?option=com_tjucm&view=item&id=' . $item->id . "&client=" . $this->client, false);
-					 $canEdit = $user->authorise('core.type.edititem', 'com_tjucm.type' . $this->ucmTypeId);
 
-					if (!$canEdit && $canEditOwn)
+					if (!$this->canEdit && $this->canEditOwn)
 					{
 						$canEdit = JFactory::getUser()->id == $item->created_by;
 					}
@@ -122,9 +114,9 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 						<?php
 						if (isset($this->items[0]->state))
 						{
-							$class = ($canChange) ? 'active' : 'disabled'; ?>
+							$class = ($this->canChange) ? 'active' : 'disabled'; ?>
 							<td class="center">
-								<a class="<?php echo $class; ?>" href="<?php echo ($canChange) ? 'index.php?option=com_tjucm&task=item.publish&id=' . $item->id . '&state=' . (($item->state + 1) % 2) . $appendUrl : '#'; ?>">
+								<a class="<?php echo $class; ?>" href="<?php echo ($this->canChange) ? 'index.php?option=com_tjucm&task=item.publish&id=' . $item->id . '&state=' . (($item->state + 1) % 2) . $appendUrl : '#'; ?>">
 								<?php
 								if ($item->state == 1)
 								{
@@ -147,7 +139,7 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 								echo JHtml::_('jgrid.checkedout', $i, $item->uEditor, $item->checked_out_time, 'items.', $canCheckin);
 							}
 							?>
-							<a href="<?php echo JRoute::_('index.php?option=com_tjucm&view=item&id='.(int) $item->id) . "&client=" . $this->client; ?>">
+							<a href="<?php echo JRoute::_('index.php?option=com_tjucm&view=item&id='.(int) $item->id . "&client=" . $this->client, false); ?>">
 								<?php echo $this->escape($item->id); ?>
 							</a>
 						</td>
@@ -163,7 +155,7 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 								}
 							}
 
-							if ($canEdit || $canDelete)
+							if ($canEdit || $this->canDelete)
 							{
 								?>
 								<td class="center">
@@ -175,7 +167,7 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 								<?php
 								}
 
-								if ($canDelete)
+								if ($this->canDelete)
 								{
 									?>
 									<a href="<?php echo 'index.php?option=com_tjucm&task=itemform.remove' . '&id=' . $item->id . $appendUrl; ?>" class="btn btn-mini delete-button" type="button"><i class="icon-delete" aria-hidden="true"></i></a>
@@ -223,7 +215,7 @@ $canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 <?php
-if ($canDelete)
+if ($this->canDelete)
 {
 	?>
 	<script type="text/javascript">

--- a/site/views/items/view.html.php
+++ b/site/views/items/view.html.php
@@ -54,6 +54,17 @@ class TjucmViewItems extends JViewLegacy
 		$user = JFactory::getUser();
 		$canCreate = $user->authorise('core.type.createitem', 'com_tjucm.type.' . $this->ucmTypeId);
 		$canView = $user->authorise('core.type.viewitem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canEdit = $user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canChange = $user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canEditOwn = $user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this->ucmTypeId);
+
+		$this->canCreate = $canCreate;
+		$this->canView = $canView;
+		$this->canEdit = $canEdit;
+		$this->canChange = $canChange;
+		$this->canEditOwn = $canEditOwn;
+		$this->canDelete = $canDelete;
 
 		// If did not get the client from url then get if from menu param
 		if (empty($this->client))
@@ -100,7 +111,7 @@ class TjucmViewItems extends JViewLegacy
 
 		if (empty($this->id))
 		{
-			if ($canCreate)
+			if ($this->canCreate)
 			{
 				$this->allowedToAdd = $itemFormModel->allowedToAddTypeData($userId, $this->client, $allowedCount);
 			}
@@ -108,11 +119,11 @@ class TjucmViewItems extends JViewLegacy
 
 		if ($this->created_by == $userId)
 		{
-			$canView = true;
+			$this->canView = true;
 		}
 
 		// Check the view access to the article (the model has already computed the values).
-		if (!$canView)
+		if (!$this->canView)
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 			$app->setHeader('status', 403, true);

--- a/site/views/items/view.html.php
+++ b/site/views/items/view.html.php
@@ -51,8 +51,7 @@ class TjucmViewItems extends JViewLegacy
 	public function display($tpl = null)
 	{
 		$app = JFactory::getApplication();
-		$input = $app->input;
-		$this->state  = $this->get('State');
+		$this->state = $this->get('State');
 		$this->items = $this->get('Items');
 		$this->pagination = $this->get('Pagination');
 		$this->params     = $app->getParams('com_tjucm');

--- a/site/views/items/view.html.php
+++ b/site/views/items/view.html.php
@@ -27,6 +27,18 @@ class TjucmViewItems extends JViewLegacy
 
 	protected $params;
 
+	protected $canCreate;
+
+	protected $canView;
+
+	protected $canEdit;
+
+	protected $canChange;
+
+	protected $canEditOwn;
+
+	protected $canDelete;
+
 	/**
 	 * Display the view
 	 *

--- a/site/views/items/view.html.php
+++ b/site/views/items/view.html.php
@@ -27,6 +27,14 @@ class TjucmViewItems extends JViewLegacy
 
 	protected $params;
 
+	protected $listcolumn;
+
+	protected $allowedToAdd;
+
+	protected $ucmTypeId;
+
+	protected $client;
+
 	protected $canCreate;
 
 	protected $canView;
@@ -38,6 +46,14 @@ class TjucmViewItems extends JViewLegacy
 	protected $canEditOwn;
 
 	protected $canDelete;
+
+	protected $menuparams;
+
+	protected $ucm_type;
+
+	protected $showList;
+
+	protected $created_by;
 
 	/**
 	 * Display the view

--- a/site/views/items/view.html.php
+++ b/site/views/items/view.html.php
@@ -185,14 +185,8 @@ class TjucmViewItems extends JViewLegacy
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
 
-		if ($menu)
-		{
-			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
-		}
-		else
-		{
-			$this->params->def('page_heading', JText::_('COM_TJUCM_DEFAULT_PAGE_TITLE'));
-		}
+		$menu ? $this->params->def('page_heading', $this->params->get('page_title', $menu->title))
+		: $this->params->def('page_heading', JText::_('COM_TJUCM_DEFAULT_PAGE_TITLE'));
 
 		$title = $this->params->get('page_title', '');
 


### PR DESCRIPTION
Steps to reproduce issue :

1) Create a new UCM type having permission for registered user as

   - Create Item: Allowed
   - View Item: Allowed
   - Edit Item: Allowed (anyone can edit the record)
  
2) Now logged in with user 1

   - Submit the form.
   - Go the list page.
   - He/she will see the list of items with 'Edit' link in 'Action' column.

3) Now logged in with user 2

   - Go the list page.

On this page, the user cannot able to see the 'Edit' link in 'Action' column (even we have set the permission as Edit Item: Allowed for this particular UCM type)



   