### PR TITLE
Issue #43 fix: Added multiple entries while clicking on submit button multiple times & Edit own permission not working for draft record as per the requirement

### DIFF
--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -1,13 +1,13 @@
 /* This function executes for autosave form */
-jQuery(document).ready(function(){
-
+jQuery(document).ready(function()
+{
 	/*Code to get item state*/
 	let itemState = jQuery('#itemState').val();
 
 	/*Code for auto save on blur event add new record or editing draft record only*/
 	if (itemState == '' || itemState == 0)
 	{
-		jQuery(document).delegate(":input[type!='button']", "blur", function() {
+		jQuery(document).on("blur", ":input[type!='button']", function() {
 			let showDraftSuccessMsg = "0";
 			steppedFormSave(this.form.id, "draft", showDraftSuccessMsg);
 		});
@@ -17,6 +17,9 @@ jQuery(document).ready(function(){
 /* This function carries stepped saving via ajax */
 function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 {
+	jQuery('#draftSave').attr('disabled', true);
+	jQuery('#finalSave').attr('disabled', true);
+
 	var item_basic_form = jQuery('#' + form_id);
 	var promise = false;
 	jQuery('#form_status').val(status);
@@ -31,11 +34,15 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 			if (!document.formvalidator.isValid('#item-form'))
 			{
 				jQuery('#finalSave').attr('disabled', false);
+				jQuery('#draftSave').attr('disabled', false);
 				return false;
 			}
 		}
 		else
 		{
+			jQuery('#draftSave').attr('disabled', false);
+			jQuery('#finalSave').attr('disabled', false);
+
 			return false;
 		}
 	}
@@ -66,7 +73,6 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 						if (showDraftSuccessMsg === "1")
 						{
 							jQuery("#draft_msg").show();
-							jQuery('#draftSave').attr('disabled', false);
 							setTimeout(function() { jQuery("#draft_msg").hide(); }, 5000);
 						}
 					}
@@ -88,7 +94,8 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 						Joomla.renderMessages({'error': returnedData.messages.error});
 					}
 				}
-
+				jQuery('#draftSave').attr('disabled', false);
+				jQuery('#finalSave').attr('disabled', false);
 			}
 		});
 	}

--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -30,6 +30,7 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 
 			if (!document.formvalidator.isValid('#item-form'))
 			{
+				jQuery('#finalSave').attr('disabled', false);
 				return false;
 			}
 		}
@@ -56,9 +57,6 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 						newUrl=url.replace(newParam,"");
 						newUrl+=newParam;
 						window.location.href =newUrl;
-
-						/*opener.location.reload();
-						window.close();*/
 					}
 					else
 					{
@@ -68,9 +66,9 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 						if (showDraftSuccessMsg === "1")
 						{
 							jQuery("#draft_msg").show();
+							jQuery('#draftSave').attr('disabled', false);
 							setTimeout(function() { jQuery("#draft_msg").hide(); }, 5000);
 						}
-
 					}
 				}
 				else
@@ -87,7 +85,7 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 
 					if(returnedData.messages.error)
 					{
-					Joomla.renderMessages({'error': returnedData.messages.error});
+						Joomla.renderMessages({'error': returnedData.messages.error});
 					}
 				}
 

--- a/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -17,9 +17,6 @@ jQuery(document).ready(function()
 /* This function carries stepped saving via ajax */
 function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 {
-	jQuery('#draftSave').attr('disabled', true);
-	jQuery('#finalSave').attr('disabled', true);
-
 	var item_basic_form = jQuery('#' + form_id);
 	var promise = false;
 	jQuery('#form_status').val(status);
@@ -51,6 +48,7 @@ function steppedFormSave(form_id, status, showDraftSuccessMsg = "1")
 	{
 		jQuery(item_basic_form).ajaxSubmit({
 			datatype:'JSON',
+			async: false,
 			success: function(data) {
 				var returnedData = JSON.parse(data);
 				if(returnedData.data != null)

--- a/site/models/item.php
+++ b/site/models/item.php
@@ -62,6 +62,7 @@ class TjucmModelItem extends JModelAdmin
 
 		// Check published state
 		if ((!$user->authorise('core.type.edititem', 'com_tjucm.type.' . $ucmId))
+			&& (!$user->authorise('core.type.editownitem', 'com_tjucm.type.' . $ucmId))
 			&& (!$user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $ucmId)))
 		{
 			$this->setState('filter.published', 1);

--- a/site/models/itemform.php
+++ b/site/models/itemform.php
@@ -110,6 +110,7 @@ class TjucmModelItemForm extends JModelForm
 
 		// Check published state
 		if ((!$user->authorise('core.type.edititem', 'com_tjucm.type.' . $ucmId))
+			&& (!$user->authorise('core.type.editownitem', 'com_tjucm.type.' . $ucmId))
 			&& (!$user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $ucmId)))
 		{
 			$this->setState('filter.published', 1);

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -47,8 +47,6 @@ $fieldsets_counter_deafult = 0;
 $setnavigation             = false;
 $itemState                 = $this->item->state;
 
-
-
 ?>
 <script type="text/javascript">
 
@@ -193,12 +191,12 @@ $itemState                 = $this->item->state;
 				if (!empty($this->allow_draft_save) && empty($itemState))
 				{
 					?>
-					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" id="draftSave" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="javascript: this.disabled=true; setTimeout(steppedFormSave, 1000, this.form.id, 'draft');" />
+					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" id="draftSave" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="steppedFormSave(this.form.id, 'draft');" />
 					<?php
 				}
 				?>
 				<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_ITEM"); ?>"
-				id="finalSave" onclick="javascript: this.disabled=true; setTimeout(steppedFormSave, 1000, this.form.id, 'save');" />
+				id="finalSave" onclick="steppedFormSave(this.form.id, 'save');" />
 				<?php
 			}
 			?>

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -191,12 +191,12 @@ $itemState                 = $this->item->state;
 				if (!empty($this->allow_draft_save) && empty($itemState))
 				{
 					?>
-					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" id="draftSave" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="steppedFormSave(this.form.id, 'draft');" />
+					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" id="draftSave" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="javascript: this.disabled=true; steppedFormSave(this.form.id, 'draft');" />
 					<?php
 				}
 				?>
 				<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_ITEM"); ?>"
-				id="finalSave" onclick="steppedFormSave(this.form.id, 'save');" />
+				id="finalSave" onclick="javascript: this.disabled=true; steppedFormSave(this.form.id, 'save');" />
 				<?php
 			}
 			?>

--- a/site/views/itemform/tmpl/default.php
+++ b/site/views/itemform/tmpl/default.php
@@ -193,12 +193,12 @@ $itemState                 = $this->item->state;
 				if (!empty($this->allow_draft_save) && empty($itemState))
 				{
 					?>
-					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="steppedFormSave(this.form.id, 'draft');" />
+					<input type="button" class="btn btn-width150 br-0 btn-default font-normal" id="draftSave" value="<?php echo JText::_("COM_TJUCM_SAVE_AS_DRAFT_ITEM"); ?>" onclick="javascript: this.disabled=true; setTimeout(steppedFormSave, 1000, this.form.id, 'draft');" />
 					<?php
 				}
 				?>
 				<input type="button" class="btn btn-success" value="<?php echo JText::_("COM_TJUCM_SAVE_ITEM"); ?>"
-				id="finalSave" onclick="steppedFormSave(this.form.id, 'save');" />
+				id="finalSave" onclick="javascript: this.disabled=true; setTimeout(steppedFormSave, 1000, this.form.id, 'save');" />
 				<?php
 			}
 			?>

--- a/site/views/items/tmpl/default.php
+++ b/site/views/items/tmpl/default.php
@@ -106,7 +106,7 @@ if (!empty($this->client))
 					$link = JRoute::_('index.php?option=com_tjucm&view=item&id=' . $item->id . "&client=" . $this->client, false);
 
 					$editown = false;
-					if (!$this->canEdit && $this->canEditOwn)
+					if ($this->canEditOwn)
 					{
 						$editown = (JFactory::getUser()->id == $item->created_by ? true : false);
 					}


### PR DESCRIPTION
**Steps to reproduce multiple entries submitted while clicking on submit/save as draft button multiple times.**

- Fill all the values for any UCM form & click multiple times on "Submit" / "Save as draft" button. It will save the record on each "Submit" / "Save as draft" button click.

**Steps to reproduce edit own permission issue on the draft record.**

1) Admin panel >> Create a UCM type with below permissions

   - Create Item: Allowed
   - View Item: Allowed
   - Edit Own Item: Allowed (Only owner of the record can edit)

2) User panel >> Save this form in draft mode.

3) Go to the UCM item list page of this UCM type & click on edit icon of that draft record.
    - Here, you will see a page with the message as "Item does not exist"

4) Go to the UCM item list page of this UCM type & click any record which will redirect to record detail page.
    - Here, you will see a page with the message as "Item does not exist"