### PR TITLE
Issue #45 fix: Does not displaying edit button/link on item detail page for edit own item permission

### DIFF
--- a/site/models/item.php
+++ b/site/models/item.php
@@ -62,6 +62,7 @@ class TjucmModelItem extends JModelAdmin
 
 		// Check published state
 		if ((!$user->authorise('core.type.edititem', 'com_tjucm.type.' . $ucmId))
+			&& (!$user->authorise('core.type.editownitem', 'com_tjucm.type.' . $ucmId))
 			&& (!$user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $ucmId)))
 		{
 			$this->setState('filter.published', 1);

--- a/site/views/item/tmpl/default.php
+++ b/site/views/item/tmpl/default.php
@@ -146,7 +146,7 @@ else
 $app = JFactory::getApplication();
 $itemid     = $app->input->getInt('Itemid', 0);
 
-if ($user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId) && $this->item->checked_out == 0)
+if (($user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId) && $this->item->checked_out == 0) || ($user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId) && JFactory::getUser()->id == $this->item->created_by))
 {
 	$redirectURL = JRoute::_('index.php?option=com_tjucm&task=item.edit&id=' . $this->item->id . '&client=' . $this->client . '&Itemid=' . $itemid, false);
 	?>

--- a/site/views/item/tmpl/default.php
+++ b/site/views/item/tmpl/default.php
@@ -146,7 +146,7 @@ else
 $app = JFactory::getApplication();
 $itemid     = $app->input->getInt('Itemid', 0);
 
-if (($user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId) && $this->item->checked_out == 0) || ($user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId) && JFactory::getUser()->id == $this->item->created_by))
+if (($user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId)) || ($user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId) && JFactory::getUser()->id == $this->item->created_by))
 {
 	$redirectURL = JRoute::_('index.php?option=com_tjucm&task=item.edit&id=' . $this->item->id . '&client=' . $this->client . '&Itemid=' . $itemid, false);
 	?>


### PR DESCRIPTION
**Steps to reproduce the issue :**

1) Create a new UCM type having permission for the registered user as

   Create Item: Allowed
   View Item: Allowed   
   Edit Own Item: Allowed (Only owner of the record can edit record)
  
2) Log in with user

   - Submit the form.
   - Go the list page.
   - User can see the list of items
   - Clicks on record from where it will redirect to the detail page

On this page, the user cannot able to see the 'Edit' link/button even we have set the permission as Edit Own Item: Allowed for this particular UCM type