### PR TITLE
Issue #55 fix: Front end user can access unpublished UCM type

### DIFF
--- a/src/components/com_tjucm/site/views/itemform/view.html.php
+++ b/src/components/com_tjucm/site/views/itemform/view.html.php
@@ -99,9 +99,15 @@ class TjucmViewItemform extends JViewLegacy
 		$tjUcmModelType = JModelLegacy::getInstance('Type', 'TjucmModel');
 		$typeId = $tjUcmModelType->getTypeId($this->client);
 
-		$TypeData = $tjUcmModelType->getItem($typeId);
+		$typeData = $tjUcmModelType->getItem($typeId);
 
-		$allowedCount = $TypeData->allowed_count;
+		// Check if the UCM type is unpublished
+		if ($typeData->state == "0")
+		{
+			return JError::raiseError(404, JText::_('COM_TJUCM_ITEM_DOESNT_EXIST'));
+		}
+
+		$allowedCount = $typeData->allowed_count;
 		$user   = JFactory::getUser();
 		$userId = $user->id;
 


### PR DESCRIPTION
**Steps to reproduce:** 

- Go to the admin panel.  
- Unpublish any UCM type & try to access that type from user panel.

Here, the user can see the form associated with this UCM type & user can submit the form even if the UCM type of this form is unpublished.
