### PR TITLE
Issue #57 fix: User cannot able to see his/her own item submissions

### DIFF
--- a/src/components/com_tjucm/site/models/items.php
+++ b/src/components/com_tjucm/site/models/items.php
@@ -69,6 +69,7 @@ class TjucmModelItems extends JModelList
 	protected function populateState($ordering = null, $direction = null)
 	{
 		$app  = JFactory::getApplication();
+		$user = JFactory::getUser();
 
 		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tjucm/models');
 		$tjUcmModelType = JModelLegacy::getInstance('Type', 'TjucmModel');
@@ -123,6 +124,13 @@ class TjucmModelItems extends JModelList
 		$this->setState("ucmType.id", $type_id);
 
 		$createdBy = $app->input->get('created_by', "", "INT");
+		$canView = $user->authorise('core.type.viewitem', 'com_tjucm.type.' . $type_id);
+
+		if (!$canView)
+		{
+			$createdBy = $createdBy ? $createdBy : $user->id;
+		}
+
 		$this->setState("created_by", $createdBy);
 
 		// List state information.

--- a/src/components/com_tjucm/site/models/items.php
+++ b/src/components/com_tjucm/site/models/items.php
@@ -128,7 +128,7 @@ class TjucmModelItems extends JModelList
 
 		if (!$canView)
 		{
-			$createdBy = $createdBy ? $createdBy : $user->id;
+			$createdBy = $user->id;
 		}
 
 		$this->setState("created_by", $createdBy);

--- a/src/components/com_tjucm/site/views/items/view.html.php
+++ b/src/components/com_tjucm/site/views/items/view.html.php
@@ -133,7 +133,6 @@ class TjucmViewItems extends JViewLegacy
 		$TypeData = $tjUcmModelType->getItem($typeId);
 
 		$allowedCount = (!empty($TypeData->allowed_count))?$TypeData->allowed_count:'0';
-		$user   = JFactory::getUser();
 		$userId = $user->id;
 
 		if (empty($this->id))
@@ -147,15 +146,6 @@ class TjucmViewItems extends JViewLegacy
 		if ($this->created_by == $userId)
 		{
 			$this->canView = true;
-		}
-
-		// Check the view access to the article (the model has already computed the values).
-		if (!$this->canView)
-		{
-			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
-			$app->setHeader('status', 403, true);
-
-			return false;
 		}
 
 		// Check for errors.


### PR DESCRIPTION
**Steps to reproduce :**

Steps to reproduce :

- Go to the admin panel. 
- Set 'View Items' ACL to 'Not Allowed' / 'Denied' of any UCM type.
- Go to the user panel & submit the item against that particular UCM type.
- Go to the item list page of that UCM type.

Here the user cannot see the list of items submitted by him/her. It shows the error/warning message like 'You are not authorized to view this resource'.