### PR TITLE
Issue #61 fix: Item detail page >> does not displaying file download option for subform file field

### DIFF
--- a/src/components/com_tjucm/administrator/assets/js/tjucm_ajaxForm_save.js
+++ b/src/components/com_tjucm/administrator/assets/js/tjucm_ajaxForm_save.js
@@ -7,8 +7,15 @@ jQuery(document).ready(function()
 	/*Code for auto save on blur event add new record or editing draft record only*/
 	if (itemState == '' || itemState == 0)
 	{
-		jQuery(document).on("blur", ":input[type!='button']", function() {
-			let showDraftSuccessMsg = "0";
+		let showDraftSuccessMsg = "0";
+		
+		// Save form values 
+		jQuery(document).on("change select", ":input", function() {
+			steppedFormSave(this.form.id, "draft", showDraftSuccessMsg);
+		});
+		
+		// To save calendar field value
+		jQuery(".field-calendar input:text").blur(function(){  
 			steppedFormSave(this.form.id, "draft", showDraftSuccessMsg);
 		});
 	}

--- a/src/components/com_tjucm/site/views/item/tmpl/default.php
+++ b/src/components/com_tjucm/site/views/item/tmpl/default.php
@@ -26,7 +26,7 @@ $fieldValueTableData->fields_value_table = JTable::getInstance('Fieldsvalue', 'T
 
 if ($this->form_extra)
 {
-$fieldSets = $this->form_extra->getFieldsets();
+	$fieldSets = $this->form_extra->getFieldsets();
 
 	// Iterate through the normal form fieldsets and display each one
 	foreach ($fieldSets as $fieldName => $fieldset)

--- a/src/components/com_tjucm/site/views/item/tmpl/default.php
+++ b/src/components/com_tjucm/site/views/item/tmpl/default.php
@@ -19,11 +19,6 @@ $fieldTableData = new stdClass;
 JTable::addIncludePath(JPATH_ROOT . '/administrator/components/com_tjfields/tables');
 $fieldTableData->tjFieldFieldTable = JTable::getInstance('field', 'TjfieldsTable');
 
-// Get Field value table
-$fieldValueTableData = new stdClass;
-JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tjfields/tables');
-$fieldValueTableData->fields_value_table = JTable::getInstance('Fieldsvalue', 'TjfieldsTable');
-
 if ($this->form_extra)
 {
 	$fieldSets = $this->form_extra->getFieldsets();
@@ -44,18 +39,13 @@ if ($this->form_extra)
 				{
 					if ($field->value)
 					{
-						// Get field value id to get the media URL
-						$fieldValueTableData->fields_value_table->load(array('value' => $field->value));
-						$extraParamArray = array();
-						$extraParamArray['id'] = $fieldValueTableData->fields_value_table->id;
+						$layout = new JLayoutFile('file', JPATH_ROOT .'/components/com_tjfields/layouts/fields');
+						$mediaLink = $layout->render(array('fieldValue'=>$field->value));
 						?>
 						<div class="form-group">
 							<div class="col-sm-2 col-xs-12"><?php echo $field->label; ?>:</div>
 							<div class="col-sm-2">
-								<?php
-								$mediaLink = $TjfieldsHelper->getMediaUrl($field->value, $extraParamArray);
-								?>
-								<a href="<?php echo $mediaLink;?>"><?php echo JText::_("COM_TJFIELDS_FILE_DOWNLOAD");?></a>
+								<?php echo $mediaLink;?>
 							</div>
 						</div>
 						<?php
@@ -88,15 +78,9 @@ if ($this->form_extra)
 											// If field type is file
 											if ($fieldTableData->tjFieldFieldTable->type == 'file')
 											{
-												// Get the field value id & subform file field id to get the media URL
-												$fieldValueTableData->fields_value_table->load(array('content_id' => $app->input->get('id', '', 'INT'), 'field_id' => $formData->id));
-												$extraParamArray = array();
-												$extraParamArray['id'] = $fieldValueTableData->fields_value_table->id;
-												$extraParamArray['subFormFileFieldId'] = $fieldTableData->tjFieldFieldTable->id;
-												$mediaLink = $TjfieldsHelper->getMediaUrl($value, $extraParamArray);
-												?>
-												<a href="<?php echo $mediaLink;?>"><?php echo JText::_("COM_TJFIELDS_FILE_DOWNLOAD");?></a>
-												<?php
+												$layout = new JLayoutFile('file', JPATH_ROOT .'/components/com_tjfields/layouts/fields');
+												$mediaLink = $layout->render(array('fieldValue'=>$value, 'isSubformField'=>'1', 'content_id'=>$app->input->get('id', '', 'INT'), 'subformFieldId'=>$formData->id,'subformFileFieldName'=>$name));
+												echo $mediaLink;
 											}
 											// If field type is checkbox
 											elseif ($fieldTableData->tjFieldFieldTable->type == 'checkbox')

--- a/src/components/com_tjucm/site/views/item/tmpl/default.php
+++ b/src/components/com_tjucm/site/views/item/tmpl/default.php
@@ -80,42 +80,40 @@ $fieldSets = $this->form_extra->getFieldsets();
 										// Get the field data by field name to check the field type
 										$fieldTableData->tjFieldFieldTable->load(array('name' => $name));
 
-										if ($fieldTableData->tjFieldFieldTable->label){?>
+										if ($value){?>
 										<div class="col-sm-2 col-xs-12"><?php echo $fieldTableData->tjFieldFieldTable->label; ?>:</div>
-										<?php } ?>
-										<div class="col-sm-10">
-										<?php
-										// If field type is file
-										if ($fieldTableData->tjFieldFieldTable->type == 'file')
-										{
-											// Get the field value id & subform file field id to get the media URL
-											$fieldValueTableData->fields_value_table->load(array('content_id' => $app->input->get('id', '', 'INT'), 'field_id' => $formData->id));
-											$extraParamArray = array();
-											$extraParamArray['id'] = $fieldValueTableData->fields_value_table->id;
-											$extraParamArray['subFormFileFieldId'] = $fieldTableData->tjFieldFieldTable->id;
-											$mediaLink = $TjfieldsHelper->getMediaUrl($value, $extraParamArray);
-											?>
-											<a href="<?php echo $mediaLink;?>"><?php echo JText::_("COM_TJFIELDS_FILE_DOWNLOAD");?></a>
+										<?php  ?>
+											<div class="col-sm-10">
 											<?php
-										}
-										// If field type is checkbox
-										elseif ($fieldTableData->tjFieldFieldTable->type == 'checkbox')
-										{
-											if ($value)
+											// If field type is file
+											if ($fieldTableData->tjFieldFieldTable->type == 'file')
+											{
+												// Get the field value id & subform file field id to get the media URL
+												$fieldValueTableData->fields_value_table->load(array('content_id' => $app->input->get('id', '', 'INT'), 'field_id' => $formData->id));
+												$extraParamArray = array();
+												$extraParamArray['id'] = $fieldValueTableData->fields_value_table->id;
+												$extraParamArray['subFormFileFieldId'] = $fieldTableData->tjFieldFieldTable->id;
+												$mediaLink = $TjfieldsHelper->getMediaUrl($value, $extraParamArray);
+												?>
+												<a href="<?php echo $mediaLink;?>"><?php echo JText::_("COM_TJFIELDS_FILE_DOWNLOAD");?></a>
+												<?php
+											}
+											// If field type is checkbox
+											elseif ($fieldTableData->tjFieldFieldTable->type == 'checkbox')
 											{
 												$checked = ($value == 1) ? ' checked="checked"' : '';
 												?>
 												<input type="checkbox" disabled="disabled" value="1" <?php echo $checked;?> />
 												<?php
 											}
-										}
-										else
-										{
-											$html = '<div class="form-group">';
-											$html .= '<div class="col-sm-10"> ' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</div>';
-											$html .= '</div>';
+											else
+											{
+												$html = '<div class="form-group">';
+												$html .= '<div class="col-sm-10"> ' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</div>';
+												$html .= '</div>';
 
-											echo  $html;
+												echo  $html;
+											}
 										}
 										?>
 										</div>

--- a/src/components/com_tjucm/site/views/item/tmpl/default.php
+++ b/src/components/com_tjucm/site/views/item/tmpl/default.php
@@ -9,9 +9,20 @@
 
 // No direct access
 defined('_JEXEC') or die;
+$app = JFactory::getApplication();
 $user = JFactory::getUser();
 JLoader::import('components.com_tjfields.helpers.tjfields', JPATH_SITE);
 $TjfieldsHelper = new TjfieldsHelper;
+
+// Get Field table
+$fieldTableData = new stdClass;
+JTable::addIncludePath(JPATH_ROOT . '/administrator/components/com_tjfields/tables');
+$fieldTableData->tjFieldFieldTable = JTable::getInstance('field', 'TjfieldsTable');
+
+// Get Field value table
+$fieldValueTableData = new stdClass;
+JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tjfields/tables');
+$fieldValueTableData->fields_value_table = JTable::getInstance('Fieldsvalue', 'TjfieldsTable');
 
 if ($this->form_extra)
 {
@@ -33,13 +44,16 @@ $fieldSets = $this->form_extra->getFieldsets();
 				{
 					if ($field->value)
 					{
+						// Get field value id to get the media URL
+						$fieldValueTableData->fields_value_table->load(array('value' => $field->value));
+						$extraParamArray = array();
+						$extraParamArray['id'] = $fieldValueTableData->fields_value_table->id;
 						?>
 						<div class="form-group">
-							<?php echo $field->label; ?>
-							<div class="col-sm-10">
+							<div class="col-sm-2 col-xs-12"><?php echo $field->label; ?>:</div>
+							<div class="col-sm-2">
 								<?php
-								$tjFieldHelper = new TjfieldsHelper;
-								$mediaLink = $tjFieldHelper->getMediaUrl($field->value);
+								$mediaLink = $TjfieldsHelper->getMediaUrl($field->value, $extraParamArray);
 								?>
 								<a href="<?php echo $mediaLink;?>"><?php echo JText::_("COM_TJFIELDS_FILE_DOWNLOAD");?></a>
 							</div>
@@ -49,23 +63,63 @@ $fieldSets = $this->form_extra->getFieldsets();
 				}
 				elseif ($field->type == 'Subform' || $field->type == 'Ucmsubform')
 				{
+					// Get Subform field data
+					$formData = $TjfieldsHelper->getFieldData($field->getAttribute('name'));
+
 					if ($field->value)
 					{
 						?>
 						<div class="form-group">
-							<?php echo $field->label; ?>
+							<div class="col-sm-2 col-xs-12"><?php echo $field->label; ?>:</div>
 							<div class="col-sm-10">
 							<?php
 								foreach ($field->value as $val)
 								{
 									foreach ($val as $name => $value)
 									{
-										// TODO : SubForm rendering
-										$html = '<div class="form-group">';
-											$html .= '<div class="col-sm-10"> ' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</div>';
-										$html .= '</div>';
+										// Get the field data by field name to check the field type
+										$fieldTableData->tjFieldFieldTable->load(array('name' => $name));
 
-										echo  $html;
+										if ($fieldTableData->tjFieldFieldTable->label){?>
+										<div class="col-sm-2 col-xs-12"><?php echo $fieldTableData->tjFieldFieldTable->label; ?>:</div>
+										<?php } ?>
+										<div class="col-sm-10">
+										<?php
+										// If field type is file
+										if ($fieldTableData->tjFieldFieldTable->type == 'file')
+										{
+											// Get the field value id & subform file field id to get the media URL
+											$fieldValueTableData->fields_value_table->load(array('content_id' => $app->input->get('id', '', 'INT'), 'field_id' => $formData->id));
+											$extraParamArray = array();
+											$extraParamArray['id'] = $fieldValueTableData->fields_value_table->id;
+											$extraParamArray['subFormFileFieldId'] = $fieldTableData->tjFieldFieldTable->id;
+											$mediaLink = $TjfieldsHelper->getMediaUrl($value, $extraParamArray);
+											?>
+											<a href="<?php echo $mediaLink;?>"><?php echo JText::_("COM_TJFIELDS_FILE_DOWNLOAD");?></a>
+											<?php
+										}
+										// If field type is checkbox
+										elseif ($fieldTableData->tjFieldFieldTable->type == 'checkbox')
+										{
+											if ($value)
+											{
+												$checked = ($value == 1) ? ' checked="checked"' : '';
+												?>
+												<input type="checkbox" disabled="disabled" value="1" <?php echo $checked;?> />
+												<?php
+											}
+										}
+										else
+										{
+											$html = '<div class="form-group">';
+											$html .= '<div class="col-sm-10"> ' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '</div>';
+											$html .= '</div>';
+
+											echo  $html;
+										}
+										?>
+										</div>
+										<?php
 									}
 
 									echo '<hr>';
@@ -82,15 +136,10 @@ $fieldSets = $this->form_extra->getFieldsets();
 					{
 						?>
 						<div class="form-group">
-							<?php echo $field->label; ?>
-							<div class="col-sm-10">
+							<div class="col-sm-2 col-xs-12"><?php echo $field->label; ?>:</div>
+							<div class="col-sm-2">
 							<?php
-								$checked = "";
-
-								if ($field->value = 1)
-								{
-									$checked = ' checked="checked"';
-								}
+								$checked = ($field->value == 1) ? ' checked="checked"' : '';
 								?>
 								<input type="checkbox" disabled="disabled" value="1" <?php echo $checked;?> />
 							</div>
@@ -104,8 +153,8 @@ $fieldSets = $this->form_extra->getFieldsets();
 					{
 						?>
 						<div class="form-group">
-							<?php echo $field->label; ?>
-							<div class="col-sm-10 form-control">
+							<div class="col-sm-2 col-xs-12"><?php echo $field->label; ?>:</div>
+							<div class="col-sm-2">
 								<?php
 								if (is_array($field->value))
 								{
@@ -143,7 +192,6 @@ else
 ?>
 <div class="form-group">
 <?php
-$app = JFactory::getApplication();
 $itemid     = $app->input->getInt('Itemid', 0);
 
 if (($user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId)) || ($user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId) && JFactory::getUser()->id == $this->item->created_by))


### PR DESCRIPTION
**Steps to reproduce :**

- Go to the admin panel. Create a subform having one file field
- Go to user panel & submit the form having this file fields.
- Go to the item detail page of a submitted form.

Here, the user will see the file name for subform file field value. Also, the user cannot see 'Download' option to download the subform file.