### PR TITLE
Issue 27: On Fresh installation `parent_id` is not adding in `#__tj_ucm_data` table

### DIFF
--- a/src/components/com_tjucm/administrator/sql/install.mysql.utf8.sql
+++ b/src/components/com_tjucm/administrator/sql/install.mysql.utf8.sql
@@ -20,6 +20,7 @@ PRIMARY KEY (`id`)
 
 CREATE TABLE IF NOT EXISTS `#__tj_ucm_data` (
 `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+`parent_id` int(11) UNSIGNED NOT NULL DEFAULT '0',
 `asset_id` INT(10) UNSIGNED NOT NULL DEFAULT '0',
 `ordering` INT(11)  NOT NULL ,
 `state` TINYINT(1)  NOT NULL ,

--- a/src/components/com_tjucm/site/helpers/tjucm.php
+++ b/src/components/com_tjucm/site/helpers/tjucm.php
@@ -87,6 +87,7 @@ class TjucmHelpersTjucm
 	public function getItemId($link)
 	{
 		$app = Factory::getApplication();
+		$db  = Factory::getDbo();
 
 		static $ucmItemIds = array();
 

--- a/src/components/com_tjucm/site/views/items/view.html.php
+++ b/src/components/com_tjucm/site/views/items/view.html.php
@@ -60,38 +60,45 @@ class TjucmViewItems extends JViewLegacy
 	 *
 	 * @param   string  $tpl  Template name
 	 *
-	 * @return void
+	 * @return boolean|void
 	 *
 	 * @throws Exception
 	 */
 	public function display($tpl = null)
 	{
-		$app = JFactory::getApplication();
-		$this->state = $this->get('State');
-		$this->items = $this->get('Items');
-		$this->pagination = $this->get('Pagination');
-		$this->params     = $app->getParams('com_tjucm');
-		$this->listcolumn = $this->get('Fields');
-		$this->allowedToAdd = false;
-
-		$model = $this->getModel("Items");
-		$this->ucmTypeId = $id = $model->getState('ucmType.id');
-		$this->client = $model->getState('ucm.client');
-
+		$app  = JFactory::getApplication();
 		$user = JFactory::getUser();
-		$canCreate = $user->authorise('core.type.createitem', 'com_tjucm.type.' . $this->ucmTypeId);
-		$canView = $user->authorise('core.type.viewitem', 'com_tjucm.type.' . $this->ucmTypeId);
-		$canEdit = $user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId);
-		$canChange = $user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $this->ucmTypeId);
-		$canEditOwn = $user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId);
-		$canDelete  = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this->ucmTypeId);
 
-		$this->canCreate = $canCreate;
-		$this->canView = $canView;
-		$this->canEdit = $canEdit;
-		$this->canChange = $canChange;
-		$this->canEditOwn = $canEditOwn;
-		$this->canDelete = $canDelete;
+		// Check the view access to the article (the model has already computed the values).
+		if (!$user->id)
+		{
+			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$app->setHeader('status', 403, true);
+
+			return false;
+		}
+
+		$this->state        = $this->get('State');
+		$this->items        = $this->get('Items');
+		$this->pagination   = $this->get('Pagination');
+		$this->params       = $app->getParams('com_tjucm');
+		$this->listcolumn   = $this->get('Fields');
+		$this->allowedToAdd = false;
+		$model              = $this->getModel("Items");
+		$this->ucmTypeId    = $id = $model->getState('ucmType.id');
+		$this->client       = $model->getState('ucm.client');
+		$canCreate          = $user->authorise('core.type.createitem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canView            = $user->authorise('core.type.viewitem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canEdit            = $user->authorise('core.type.edititem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canChange          = $user->authorise('core.type.edititemstate', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canEditOwn         = $user->authorise('core.type.editownitem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$canDelete          = $user->authorise('core.type.deleteitem', 'com_tjucm.type.' . $this->ucmTypeId);
+		$this->canCreate    = $canCreate;
+		$this->canView      = $canView;
+		$this->canEdit      = $canEdit;
+		$this->canChange    = $canChange;
+		$this->canEditOwn   = $canEditOwn;
+		$this->canDelete    = $canDelete;
 
 		// If did not get the client from url then get if from menu param
 		if (empty($this->client))

--- a/src/components/com_tjucm/site/views/items/view.html.php
+++ b/src/components/com_tjucm/site/views/items/view.html.php
@@ -69,7 +69,7 @@ class TjucmViewItems extends JViewLegacy
 		$app  = JFactory::getApplication();
 		$user = JFactory::getUser();
 
-		// Check the view access to the article (the model has already computed the values).
+		// Check the view access to the items.
 		if (!$user->id)
 		{
 			$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');


### PR DESCRIPTION
While installing UCM package on fresh site `parent_id` is not adding in `#__tj_ucm_data` table. Handle it only in update case. #110