### PR TITLE
Bug #154051 Frontend->Form view->Form Title is missing

### DIFF
--- a/src/components/com_tjucm/site/views/itemform/tmpl/default.php
+++ b/src/components/com_tjucm/site/views/itemform/tmpl/default.php
@@ -116,17 +116,36 @@ JFactory::getDocument()->addScriptDeclaration('
 	</div>
 	<?php
 	if ($this->form_extra)
-	{
+	{	
+		if(isset($_GET['id']))
+		{
+			?>
+			<div class="page-header clearfix">
+			<h1 class="page-title">
+			<?php echo "<p style='color:blue 'size:100'>"." EDIT : ". strtoupper($this->params['ucm_type'])."    FORM" . "</p>";?>
+			<h1>
+			</div> 
+			<?php	
+		}
+		else
+		{
+			?>
+			<div class="page-header clearfix">
+			<h1 class="page-title">
+			<?php echo "<p style='color:blue 'size:100'>" . strtoupper($this->params['ucm_type'])."    FORM" . "</p>";?>
+			<h1>
+			</div>
+			<?php
+		}
 		?>
 		<div class="form-horizontal">
-		<?php
-		// Code to display the form
-		echo $this->loadTemplate('extrafields');
-		?>
+			<?php
+				// Code to display the form
+				echo $this->loadTemplate('extrafields');
+			?>
 		</div>
 		<?php
 	}
-
 	if ($editRecordId)
 	{
 	?>


### PR DESCRIPTION
Steps:
1.login to site.
2.Click on form menu then it must show the title of form.

Expected:
As per the ucm type the form title must changed.

Actual:Title is missing